### PR TITLE
[SYNPYTH-39] SchemaFiled & SchemaManager

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
         'requests==2.5.1',
         'six==1.9.0',
         'python-slugify==0.1.0',
+        'validictory==1.0.0',
     ],
     tests_require=[
         'mock>=1.0.1',

--- a/syncano/models/base.py
+++ b/syncano/models/base.py
@@ -241,7 +241,7 @@ class Instance(Model):
     role = fields.Field(read_only=True, required=False)
     owner = fields.ModelField('Admin', read_only=True)
     links = fields.HyperlinkedField(links=LINKS)
-    metadata = fields.Field(read_only=False, required=False)
+    metadata = fields.JSONField(read_only=False, required=False)
     created_at = fields.DateTimeField(read_only=True, required=False)
     updated_at = fields.DateTimeField(read_only=True, required=False)
 
@@ -290,10 +290,10 @@ class Class(Model):
     description = fields.StringField(read_only=False, required=False)
     objects_count = fields.Field(read_only=True, required=False)
 
-    schema = fields.Field(read_only=False, required=True)
+    schema = fields.SchemaField(read_only=False, required=True)
     links = fields.HyperlinkedField(links=LINKS)
     status = fields.Field()
-    metadata = fields.Field(read_only=False, required=False)
+    metadata = fields.JSONField(read_only=False, required=False)
 
     revision = fields.IntegerField(read_only=True, required=False)
     expected_revision = fields.IntegerField(read_only=False, required=False)

--- a/syncano/models/fields.py
+++ b/syncano/models/fields.py
@@ -459,8 +459,9 @@ class SchemaField(JSONField):
             raise self.VaidationError('Field names must be unique.')
 
         for field in value:
+            is_not_indexable = field['type'] in self.not_indexable_types
             has_index = ('order_index' in field or 'filter_index' in field)
-            if field['type'] in self.not_indexable_types and has_index:
+            if is_not_indexable and has_index:
                 raise self.VaidationError('"{0}" type is not indexable.'.format(field['type']))
 
     def to_python(self, value):

--- a/syncano/models/fields.py
+++ b/syncano/models/fields.py
@@ -6,7 +6,7 @@ from datetime import date, datetime
 
 from syncano import logger
 from syncano.exceptions import SyncanoFieldError, SyncanoValueError
-from .manager import RelatedManagerDescriptor
+from .manager import RelatedManagerDescriptor, SchemaManager
 from .registry import registry
 
 
@@ -446,6 +446,19 @@ class SchemaField(JSONField):
             }
         }
     }
+
+    def to_python(self, value):
+        if isinstance(value, SchemaManager):
+            return value
+
+        value = super(SchemaField, self).to_python(value)
+        return SchemaManager(value)
+
+    def to_native(self, value):
+        if isinstance(value, SchemaManager):
+            value = value.schema
+
+        return super(SchemaField, self).to_native(value)
 
 
 MAPPING = {

--- a/syncano/models/fields.py
+++ b/syncano/models/fields.py
@@ -408,7 +408,44 @@ class JSONField(WritableField):
 
 
 class SchemaField(JSONField):
-    pass
+    schema = {
+        'type': 'array',
+        'items': {
+            'type': 'object',
+            'properties': {
+                'name': {
+                    'type': 'string',
+                    'required': True,
+                },
+                'type': {
+                    'type': 'string',
+                    'required': True,
+                    'enum': [
+                        'string',
+                        'text',
+                        'integer',
+                        'float',
+                        'boolean',
+                        'datetime',
+                        'file',
+                        'reference'
+                    ],
+                },
+                'order_index': {
+                    'type': 'boolean',
+                    'required': False,
+                },
+                'filter_index': {
+                    'type': 'boolean',
+                    'required': False,
+                },
+                'target': {
+                    'type': 'string',
+                    'required': False,
+                }
+            }
+        }
+    }
 
 
 MAPPING = {

--- a/syncano/models/fields.py
+++ b/syncano/models/fields.py
@@ -447,6 +447,12 @@ class SchemaField(JSONField):
         }
     }
 
+    def validate(self, value, model_instance):
+        if isinstance(value, SchemaManager):
+            value = value.schema
+
+        super(SchemaField, self).validate(value, model_instance)
+
     def to_python(self, value):
         if isinstance(value, SchemaManager):
             return value

--- a/syncano/models/manager.py
+++ b/syncano/models/manager.py
@@ -38,7 +38,7 @@ class RelatedManagerDescriptor(object):
 
     def __get__(self, instance, owner=None):
         if instance is None:
-            raise AttributeError("Manager is accessible only via {0} instances.".format(owner.__name__))
+            raise AttributeError("RelatedManager is accessible only via {0} instances.".format(owner.__name__))
 
         links = getattr(instance, self.field.name)
         path = links[self.name]
@@ -368,3 +368,74 @@ class ObjectManager(Manager):
         parent = self.model._meta.parent
         class_ = parent.please.get(instance_name, class_name)
         return class_.schema
+
+
+class SchemaManager(object):
+
+    def __init__(self, schema=None):
+        self.schema = schema or []
+
+    def __str__(self):
+        return str(self.schema)
+
+    def __repr__(self):
+        return '<SchemaManager>'
+
+    def __getitem__(self, key):
+        if isinstance(key, int):
+            return self.schema[key]
+
+        if isinstance(key, six.string_types):
+            for v in self.schema:
+                if v.get('name') == key:
+                    return v
+
+        raise KeyError
+
+    def __setitem__(self, key, value):
+        value = deepcopy(value)
+        value['name'] = key
+        self.remove(key)
+        self.add(value)
+
+    def __delitem__(self, key):
+        self.remove(key)
+
+    def __iter__(self):
+        return iter(self.schema)
+
+    def __contains__(self, item):
+        if not self.schema:
+            return False
+        return item in self.schema
+
+    def set(self, value):
+        self.schema = value
+
+    def add(self, *objects):
+        self.schema.extend(objects)
+
+    def remove(self, *names):
+        values = [v for v in self.schema if v.get('name') not in names]
+        self.set(values)
+
+    def clear(self):
+        self.set([])
+
+    def set_index(self, field, index_type):
+        pass
+
+    def set_order_index(self, field):
+        self.set_index(field, 'order_index')
+
+    def set_filter_index(self, field):
+        self.set_index(field, 'filter_index')
+
+    def remove_index(field, index_type):
+        pass
+
+    def remove_order_index(self, field):
+        self.remove_index(field, 'order_index')
+
+    def remove_filter_index(self, field):
+        self.remove_index(field, 'filter_index')

--- a/syncano/models/manager.py
+++ b/syncano/models/manager.py
@@ -422,21 +422,34 @@ class SchemaManager(object):
     def clear(self):
         self.set([])
 
-    def set_index(self, field, index_type):
-        self[field][index_type] = True
+    def set_index(self, field, order=False, filter=False):
+        if not order and not filter:
+            raise ValueError('Choose at least one index.')
+
+        if order:
+            self[field]['order_index'] = True
+
+        if filter:
+            self[field]['filter_index'] = True
 
     def set_order_index(self, field):
-        self.set_index(field, 'order_index')
+        self.set_index(field, order=True)
 
     def set_filter_index(self, field):
-        self.set_index(field, 'filter_index')
+        self.set_index(field, filter=True)
 
-    def remove_index(self, field, index_type):
-        if index_type in self[field]:
-            del self[field][index_type]
+    def remove_index(self, field, order=False, filter=False):
+        if not order and not filter:
+            raise ValueError('Choose at least one index.')
+
+        if order and 'order_index' in self[field]:
+            del self[field]['order_index']
+
+        if filter and 'filter_index' in self[field]:
+            del self[field]['filter_index']
 
     def remove_order_index(self, field):
-        self.remove_index(field, 'order_index')
+        self.remove_index(field, order=True)
 
     def remove_filter_index(self, field):
-        self.remove_index(field, 'filter_index')
+        self.remove_index(field, filter=True)

--- a/syncano/models/manager.py
+++ b/syncano/models/manager.py
@@ -423,7 +423,7 @@ class SchemaManager(object):
         self.set([])
 
     def set_index(self, field, index_type):
-        pass
+        self[field][index_type] = True
 
     def set_order_index(self, field):
         self.set_index(field, 'order_index')
@@ -431,8 +431,8 @@ class SchemaManager(object):
     def set_filter_index(self, field):
         self.set_index(field, 'filter_index')
 
-    def remove_index(field, index_type):
-        pass
+    def remove_index(self, field, index_type):
+        del self[field][index_type]
 
     def remove_order_index(self, field):
         self.remove_index(field, 'order_index')

--- a/syncano/models/manager.py
+++ b/syncano/models/manager.py
@@ -387,7 +387,7 @@ class SchemaManager(object):
 
         if isinstance(key, six.string_types):
             for v in self.schema:
-                if v.get('name') == key:
+                if v['name'] == key:
                     return v
 
         raise KeyError
@@ -416,7 +416,7 @@ class SchemaManager(object):
         self.schema.extend(objects)
 
     def remove(self, *names):
-        values = [v for v in self.schema if v.get('name') not in names]
+        values = [v for v in self.schema if v['name'] not in names]
         self.set(values)
 
     def clear(self):
@@ -432,7 +432,8 @@ class SchemaManager(object):
         self.set_index(field, 'filter_index')
 
     def remove_index(self, field, index_type):
-        del self[field][index_type]
+        if index_type in self[field]:
+            del self[field][index_type]
 
     def remove_order_index(self, field):
         self.remove_index(field, 'order_index')


### PR DESCRIPTION
Few examples:

```python
cls.schema                              # SchemaManager instance
cls.schema[0]                           # access via index
cls.schema['henryk']                    # access via schema field name
cls.schema.add({}, {}, {})              # add many objects at once
cls.schema.remove('henryk', 'ala')      # remove many objects at once
cls.schema.clear()                      # clear all entries

# Index managment
cls.schema.set_index('henryk', order=True)
cls.schema.set_index('henryk', filter=True)
cls.schema.set_index('henryk', order=True, filter=True)
cls.schema.set_order_index('henryk')
cls.schema.set_filter_index('henryk')
cls.schema.remove_index('henryk', order=True, filter=True)
cls.schema.remove_order_index(...)
cls.schema.remove_filter_index(...)
```