### PR TITLE
[SYNPYTH-56] Support for CodeBox run endpoint

### DIFF
--- a/syncano/connection.py
+++ b/syncano/connection.py
@@ -163,6 +163,7 @@ class Connection(object):
         """
         params = self.build_params(kwargs)
         method = getattr(self.session, method_name.lower(), None)
+        encode_request = kwargs.pop('encode_request', True)
 
         # JSON dump can be expensive
         if syncano.DEBUG:
@@ -178,7 +179,7 @@ class Connection(object):
             raise SyncanoValueError('Invalid request method: {0}.'.format(method_name))
 
         # Encode request payload
-        if 'data' in params and not isinstance(params['data'], six.string_types):
+        if encode_request and 'data' in params and not isinstance(params['data'], six.string_types):
             params['data'] = json.dumps(params['data'])
 
         url = self.build_url(path)

--- a/syncano/connection.py
+++ b/syncano/connection.py
@@ -163,7 +163,6 @@ class Connection(object):
         """
         params = self.build_params(kwargs)
         method = getattr(self.session, method_name.lower(), None)
-        encode_request = kwargs.pop('encode_request', True)
 
         # JSON dump can be expensive
         if syncano.DEBUG:
@@ -179,7 +178,7 @@ class Connection(object):
             raise SyncanoValueError('Invalid request method: {0}.'.format(method_name))
 
         # Encode request payload
-        if encode_request and 'data' in params and not isinstance(params['data'], six.string_types):
+        if 'data' in params and not isinstance(params['data'], six.string_types):
             params['data'] = json.dumps(params['data'])
 
         url = self.build_url(path)

--- a/syncano/models/base.py
+++ b/syncano/models/base.py
@@ -419,6 +419,7 @@ class CodeBox(Model):
         **CodeBox** has special method called ``run`` which will execute attached source code::
 
             >>> CodeBox.please.run('instance-name', 1234, payload={'variable_one': 1, 'variable_two': 2})
+            >>> CodeBox.please.run('instance-name', 1234, payload="{\"variable_one\": 1, \"variable_two\": 2}")
 
         or via instance::
 
@@ -429,6 +430,8 @@ class CodeBox(Model):
     LINKS = (
         {'type': 'detail', 'name': 'self'},
         {'type': 'list', 'name': 'runtimes'},
+        # This will cause name collision between model run method
+        # and HyperlinkedField dynamic methods.
         # {'type': 'detail', 'name': 'run'},
         {'type': 'detail', 'name': 'traces'},
     )

--- a/syncano/models/base.py
+++ b/syncano/models/base.py
@@ -473,7 +473,6 @@ class CodeBox(Model):
         endpoint = self.links['run']
         connection = self._get_connection(**payload)
         request = {
-            'encode_request': False,
             'data': {
                 'payload': json.dumps(payload)
             }

--- a/syncano/models/base.py
+++ b/syncano/models/base.py
@@ -8,7 +8,7 @@ import six
 from syncano.exceptions import SyncanoValidationError, SyncanoDoesNotExist
 from . import fields
 from .options import Options
-from .manager import Manager, WebhookManager, ObjectManager
+from .manager import Manager, WebhookManager, ObjectManager, CodeBoxManager
 from .registry import registry
 
 
@@ -446,6 +446,8 @@ class CodeBox(Model):
     name = fields.StringField(max_length=80)
     created_at = fields.DateTimeField(read_only=True, required=False)
     updated_at = fields.DateTimeField(read_only=True, required=False)
+
+    please = CodeBoxManager()
 
     class Meta:
         parent = Instance

--- a/syncano/models/manager.py
+++ b/syncano/models/manager.py
@@ -496,9 +496,14 @@ class CodeBoxManager(Manager):
 
     @clone
     def run(self, *args, **kwargs):
+        payload = kwargs.pop('payload', {})
+
+        if not isinstance(payload, six.string_types):
+            payload = json.dumps(payload)
+
         self.method = 'POST'
         self.endpoint = 'run'
-        self.data['payload'] = json.dumps(kwargs.pop('payload', {}))
+        self.data['payload'] = payload
         self._filter(*args, **kwargs)
         self._serialize = False
         return self.request()

--- a/syncano/models/manager.py
+++ b/syncano/models/manager.py
@@ -496,13 +496,12 @@ class CodeBoxManager(Manager):
 
     @clone
     def run(self, *args, **kwargs):
-        payload = kwargs.pop('payload', {})
         self.method = 'POST'
         self.endpoint = 'run'
-        self.data['payload'] = json.dumps(payload)
+        self.data['payload'] = json.dumps(kwargs.pop('payload', {}))
         self._filter(*args, **kwargs)
         self._serialize = False
-        return self.request(encode_request=False)
+        return self.request()
 
 
 class WebhookManager(Manager):

--- a/syncano/models/manager.py
+++ b/syncano/models/manager.py
@@ -488,6 +488,23 @@ class Manager(ConnectionMixin):
             response = self.request(path=next_url)
 
 
+class CodeBoxManager(Manager):
+    """
+    Custom :class:`~syncano.models.manager.Manager`
+    class for :class:`~syncano.models.base.CodeBox` model.
+    """
+
+    @clone
+    def run(self, *args, **kwargs):
+        payload = kwargs.pop('payload', {})
+        self.method = 'POST'
+        self.endpoint = 'run'
+        self.data['payload'] = json.dumps(payload)
+        self._filter(*args, **kwargs)
+        self._serialize = False
+        return self.request(encode_request=False)
+
+
 class WebhookManager(Manager):
     """
     Custom :class:`~syncano.models.manager.Manager`


### PR DESCRIPTION
I've added `run` method to `CodeBox` model and manager e.g:

```python
CodeBox.please.run('instance-name', 1234, payload={'variable_one': 1, 'variable_two': 2})

# With raw JSON
CodeBox.please.run('instance-name', 1234, payload="{\"variable_one\": 1, \"variable_two\": 2}")

cb = CodeBox.please.get('instance-name', 1234)
cb.run(variable_one=1, variable_two=2)
``` 