### PR TITLE
[SYNPYTH-63] ORM update error

### DIFF
--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -163,7 +163,7 @@ class ManagerTestCase(unittest.TestCase):
         filter_mock.assert_called_once_with(1, 2, a=1, b=2)
         request_mock.assert_called_once_with()
 
-        self.assertEqual(self.manager.method, 'PUT')
+        self.assertEqual(self.manager.method, 'PATCH')
         self.assertEqual(self.manager.endpoint, 'detail')
         self.assertEqual(self.manager.data, {'x': 1, 'y': 2})
 
@@ -344,6 +344,10 @@ class ManagerTestCase(unittest.TestCase):
         with self.assertRaises(SyncanoValueError):
             self.manager.request()
 
+        self.manager.method = 'dummy'
+        with self.assertRaises(SyncanoValueError):
+            self.manager.request()
+
     @mock.patch('syncano.models.manager.Manager.request')
     def test_iterator(self, request_mock):
         request_mock.side_effect = [
@@ -366,6 +370,18 @@ class ManagerTestCase(unittest.TestCase):
         self.assertTrue(request_mock.called)
         self.assertEqual(request_mock.call_count, 2)
         request_mock.assert_called_with(path='next_url')
+
+    def test_get_allowed_method(self):
+        self.manager.endpoint = 'detail'
+
+        result = self.manager.get_allowed_method('GET', 'POST')
+        self.assertEqual(result, 'GET')
+
+        result = self.manager.get_allowed_method('DELETE', 'POST')
+        self.assertEqual(result, 'DELETE')
+
+        with self.assertRaises(SyncanoValueError):
+            self.manager.get_allowed_method('dummy')
 
 
 class CodeBoxManagerTestCase(unittest.TestCase):


### PR DESCRIPTION
Fix for:

```
Traceback (most recent call last):
File "examples.py", line 9, in <module>
Object.please.update(id=6, data={'hype': 'fooblax'}, instance_name="watwat", class_name="whyclass")
File "/Users/adam/Syncano/syncano-python/syncano/models/manager.py", line 23, in inner
return func(self, *args, **kwargs)
File "/Users/adam/Syncano/syncano-python/syncano/models/manager.py", line 247, in update
return self.request()
File "/Users/adam/Syncano/syncano-python/syncano/models/manager.py", line 458, in request
response = self.connection.request(method, path, **request)
File "/Users/adam/Syncano/syncano-python/syncano/connection.py", line 148, in request
return self.make_request(method_name, path, **kwargs)
File "/Users/adam/Syncano/syncano-python/syncano/connection.py", line 197, in make_request
raise SyncanoRequestError(response.status_code, content)
syncano.exceptions.SyncanoRequestError: 405 Method 'PUT' not allowed.
```