### PR TITLE
[SYNPYTH-101] check if instance is specified

### DIFF
--- a/syncano/models/fields.py
+++ b/syncano/models/fields.py
@@ -74,7 +74,8 @@ class Field(object):
         return six.u(repr(self))
 
     def __get__(self, instance, owner):
-        return instance._raw_data.get(self.name, self.default)
+        if instance is not None:
+            return instance._raw_data.get(self.name, self.default)
 
     def __set__(self, instance, value):
         if self.read_only and value and instance._raw_data.get(self.name):


### PR DESCRIPTION
we prevent this:

$>>> connection.ApiKey.api_key

Traceback (most recent call last):

 File "<stdin>", line 1, in <module>

 File "/usr/local/lib/python2.7/site-packages/syncano/models/fields.py", line 77, in __get__

   return instance._raw_data.get(self.name, self.default)

AttributeError: 'NoneType' object has no attribute '_raw_data'

 