### PR TITLE
[SYNPYTH-123] Correct creating error message

### DIFF
--- a/syncano/exceptions.py
+++ b/syncano/exceptions.py
@@ -32,7 +32,9 @@ class SyncanoRequestError(SyncanoException):
         self.status_code = status_code
 
         if isinstance(reason, dict):
-            message = ''.join(reason.get(k, '') for k in ['detail', 'error', '__all__'])
+            joined_details = (''.join(reason.get(k, '')) for k in ['detail', 'error', '__all__'])
+            message = ''.join(joined_details)
+
             if not message:
                 for name, value in six.iteritems(reason):
                     if isinstance(value, (list, dict)):


### PR DESCRIPTION
It turned out that sometimes we get list inside join (validation error during migration). My fix converts this list to string, with unpacking from list to avoid brackets in error message.