### PR TITLE
[SYNPYTH-114] add field mapping

### DIFF
--- a/syncano/models/base.py
+++ b/syncano/models/base.py
@@ -204,7 +204,10 @@ class Model(six.with_metaclass(ModelMetaclass)):
                 value = getattr(self, field.name)
                 if not value and field.blank:
                     continue
-                data[field.name] = field.to_native(value)
+                if field.mapping:
+                    data[field.mapping] = field.to_native(value)
+                else:
+                    data[field.name] = field.to_native(value)
         return data
 
     def get_endpoint_data(self):
@@ -885,7 +888,7 @@ class Trigger(Model):
 
     label = fields.StringField(max_length=80)
     codebox = fields.IntegerField(label='codebox id')
-    klass = fields.StringField(label='class name')
+    klass = fields.StringField(label='class name', mapping='class')
     signal = fields.ChoiceField(choices=SIGNAL_CHOICES)
     links = fields.HyperlinkedField(links=LINKS)
     created_at = fields.DateTimeField(read_only=True, required=False)

--- a/syncano/models/fields.py
+++ b/syncano/models/fields.py
@@ -37,6 +37,7 @@ class Field(object):
         self.read_only = kwargs.pop('read_only', self.read_only)
         self.blank = kwargs.pop('blank', self.blank)
         self.label = kwargs.pop('label', None)
+        self.mapping = kwargs.pop('mapping', None)
         self.max_length = kwargs.pop('max_length', None)
         self.min_length = kwargs.pop('min_length', None)
         self.query_allowed = kwargs.pop('query_allowed', self.query_allowed)


### PR DESCRIPTION
Because of using Python keyword 'class' in JSON representation of Trigger - we have to enable similar field mapping as was performed in API.