### PR TITLE
[SYNPYTH-90] DO file handling

### DIFF
--- a/syncano/connection.py
+++ b/syncano/connection.py
@@ -187,6 +187,7 @@ class Connection(object):
         content = self.get_response_content(url, response)
 
         if files:
+            # remove 'data' and 'content-type' to avoid "ValueError: Data must not be a string."
             params.pop('data')
             params['headers'].pop('content-type')
             params['files'] = files
@@ -195,8 +196,8 @@ class Connection(object):
                 url = '{}{}/'.format(url, content['id'])
 
             patch = getattr(self.session, 'patch')
+            # second request is needed to upload a file
             response = patch(url, **params)
-
             content = self.get_response_content(url, response)
 
         return content

--- a/syncano/models/base.py
+++ b/syncano/models/base.py
@@ -128,6 +128,7 @@ class Model(six.with_metaclass(ModelMetaclass)):
 
         endpoint = self._meta.resolve_endpoint(endpoint_name, properties)
         request = {'data': data}
+
         response = connection.request(method, endpoint, **request)
 
         self.to_python(response)
@@ -204,7 +205,10 @@ class Model(six.with_metaclass(ModelMetaclass)):
                 value = getattr(self, field.name)
                 if not value and field.blank:
                     continue
-                data[field.name] = field.to_native(value)
+
+                param_name = getattr(field, 'param_name', field.name)
+                data[param_name] = field.to_native(value)
+
         return data
 
     def get_endpoint_data(self):

--- a/syncano/models/fields.py
+++ b/syncano/models/fields.py
@@ -467,6 +467,13 @@ class ModelField(Field):
         return value
 
 
+class FileField(WritableField):
+    param_name = 'files'
+
+    def to_native(self, value):
+        return {self.name: value}
+
+
 class JSONField(WritableField):
     query_allowed = False
     schema = None
@@ -575,7 +582,7 @@ class SchemaField(JSONField):
 MAPPING = {
     'string': StringField,
     'text': StringField,
-    'file': StringField,
+    'file': FileField,
     'ref': StringField,
     'reference': ReferenceField,
     'integer': IntegerField,


### PR DESCRIPTION
Tried to find solution that will be less painful than changing request pipeline, but needed to take into account few things:

1. user needs to pass open file to create object
2. file needs to be open during request (deepcopy in build_params)
3. file is passed as separate kwarg in requests lib
4. our traditional request has app/json in content-type header (request attrs must be serializable)
5. python file object is not serializable

The solution provides additional request for file, and updates newly created DO.