### PR TITLE
Lib 278 - add count method to the object manager.

### DIFF
--- a/syncano/models/incentives.py
+++ b/syncano/models/incentives.py
@@ -48,6 +48,7 @@ class CodeBox(Model):
         {'display_name': 'nodejs', 'value': 'nodejs'},
         {'display_name': 'python', 'value': 'python'},
         {'display_name': 'ruby', 'value': 'ruby'},
+        {'display_name': 'golang', 'value': 'golang'},
     )
 
     label = fields.StringField(max_length=80)

--- a/syncano/models/manager.py
+++ b/syncano/models/manager.py
@@ -742,9 +742,31 @@ class ObjectManager(Manager):
         'eq', 'neq', 'exists', 'in',
     ]
 
+    def __init__(self):
+        super(ObjectManager, self).__init__()
+        self.query = {
+            'include_count': True,
+        }
+
     def serialize(self, data, model=None):
         model = model or self.model.get_subclass_model(**self.properties)
         return super(ObjectManager, self).serialize(data, model)
+
+    @clone
+    def count(self):
+        """
+        Return the queryset count;
+
+        Usage::
+            Object.please.list(instance_name='raptor', class_name='some_class').filter(id__gt=600).count()
+            Object.please.list(instance_name='raptor', class_name='some_class').count()
+            Object.please.all(instance_name='raptor', class_name='some_class').count()
+        :return: The integer with estimated objects count;
+        """
+        self.method = 'GET'
+        self.query.update({'page_size': 0})
+        response = self.request()
+        return response['objects_count']
 
     @clone
     def filter(self, **kwargs):

--- a/syncano/models/manager.py
+++ b/syncano/models/manager.py
@@ -742,12 +742,6 @@ class ObjectManager(Manager):
         'eq', 'neq', 'exists', 'in',
     ]
 
-    def __init__(self):
-        super(ObjectManager, self).__init__()
-        self.query = {
-            'include_count': True,
-        }
-
     def serialize(self, data, model=None):
         model = model or self.model.get_subclass_model(**self.properties)
         return super(ObjectManager, self).serialize(data, model)
@@ -764,7 +758,10 @@ class ObjectManager(Manager):
         :return: The integer with estimated objects count;
         """
         self.method = 'GET'
-        self.query.update({'page_size': 0})
+        self.query.update({
+            'include_count': True,
+            'page_size': 0,
+        })
         response = self.request()
         return response['objects_count']
 


### PR DESCRIPTION
Guys, I can't find some use case for lib when only include_count parameter is provided- so I skipped that case, if you find some sensible use case - I will implement it.

Usage:

Object.please.list(instance_name='raptor', class_name='newclass').filter(id__gt=600).count() >> 177
Object.please.list(instance_name='raptor', class_name='newclass').count() >> 774
Object.please.all(instance_name='raptor', class_name='newclass').count() >> 774