### PR TITLE
LIB 274 - Handle Custom responses in Webhooks/Codeboxes

### DIFF
--- a/syncano/models/custom_response.py
+++ b/syncano/models/custom_response.py
@@ -113,18 +113,12 @@ class CustomResponseMixin(object):
 
     @property
     def status_code(self):
-        if not self.result:
-            return None
-        return self.result.get('response', {}).get('status')
+        return self.result.get('response', {}).get('status') if self.result else None
 
     @property
     def error(self):
-        if not self.result:
-            return None
-        return self.result.get('stderr')
+        return self.result.get('stderr') if self.result else None
 
     @property
     def content_type(self):
-        if not self.result:
-            return None
-        return self.result.get('response', {}).get('content_type')
+        return self.result.get('response', {}).get('content_type') if self.result else None

--- a/syncano/models/custom_response.py
+++ b/syncano/models/custom_response.py
@@ -1,0 +1,62 @@
+import json
+
+
+class CustomResponseHandler(object):
+
+    def __init__(self):
+        # a content_type -> handler method dict
+        self.handlers = {}
+
+    def register_handler(self, content_type, handler):
+        self.handlers[content_type] = handler
+
+    def process_response(self, response):
+        content_type = self._find_content_type(response)
+        try:
+            return self.handlers[content_type](response)
+        except KeyError:
+            return self._default_handler(response)
+
+    @staticmethod
+    def _find_content_type(response):
+        return response.get('response', {}).get('content_type')
+
+    @staticmethod
+    def _default_handler(response):
+        if 'response' in response:
+            return response['response']
+        if 'stdout' in response:
+            return response['stdout']
+
+        return response
+
+    @staticmethod
+    def json_handler(response):
+        return json.loads(response['response']['content'])
+
+    @staticmethod
+    def plain_handler(response):
+        return response['response']['content']
+
+custom_response_handler = CustomResponseHandler()
+custom_response_handler.register_handler('application/json', CustomResponseHandler.json_handler)
+custom_response_handler.register_handler('text/plain', CustomResponseHandler.plain_handler)
+
+
+class CustomResponseMixin(object):
+
+    @property
+    def content(self):
+        return custom_response_handler.process_response(self.result)
+
+    @property
+    def response_status(self):
+        return self.result.get('response', {}).get('status')
+
+    @property
+    def error(self):
+        return self.result.get('stderr')
+
+    @property
+    def content_type(self):
+        return self.result.get('response', {}).get('content_type')

--- a/syncano/models/custom_response.py
+++ b/syncano/models/custom_response.py
@@ -69,10 +69,15 @@ class CustomResponseHandler(object):
 
     @staticmethod
     def _find_content_type(response):
+        if not response:
+            return None
         return response.get('response', {}).get('content_type')
 
     @staticmethod
     def _default_handler(response):
+        if not response:
+            return None
+
         if 'response' in response:
             return response['response']
         if 'stdout' in response:
@@ -108,12 +113,18 @@ class CustomResponseMixin(object):
 
     @property
     def status_code(self):
+        if not self.result:
+            return None
         return self.result.get('response', {}).get('status')
 
     @property
     def error(self):
+        if not self.result:
+            return None
         return self.result.get('stderr')
 
     @property
     def content_type(self):
+        if not self.result:
+            return None
         return self.result.get('response', {}).get('content_type')

--- a/syncano/models/custom_response.py
+++ b/syncano/models/custom_response.py
@@ -1,13 +1,63 @@
 import json
 
+from syncano.exceptions import SyncanoException
+
 
 class CustomResponseHandler(object):
+    """
+    A helper class which allows to define and maintain custom response handlers.
 
+    Consider an example:
+    CodeBox code:
+
+      >> set_response(HttpResponse(status_code=200, content='{"one": 1}', content_type='application/json'))
+
+    When suitable CodeBoxTrace is used:
+
+      >> trace = CodeBoxTrace.please.get(id=<code_box_trace_id>, codebox_id=<codebox_id>)
+
+    Then trace object will have a content attribute, which will be a dict created from json (simple: json.loads under
+      the hood);
+
+    So this is possible:
+
+      >> trace.content['one']
+
+    And the trace.content is equal to:
+      >> {'one': 1}
+
+    The handler can be easily overwrite:
+
+    def custom_handler(response):
+        return json.loads(response['response']['content'])['one']
+
+    trace.response_handler.overwrite_handler('application/json', custom_handler)
+
+    or globally:
+
+    CodeBoxTrace.response_handler.overwrite_handler('application/json', custom_handler)
+
+    Then trace.content is equal to:
+      >> 1
+
+    Currently supported content_types (but any handler can be defined):
+      * application/json
+      * text/plain
+
+    """
     def __init__(self):
-        # a content_type -> handler method dict
         self.handlers = {}
+        self.register_handler('application/json', self.json_handler)
+        self.register_handler('plain/text', self.plain_handler)
 
     def register_handler(self, content_type, handler):
+        if content_type in self.handlers:
+            raise SyncanoException('Handler "{}" already defined. User overwrite_handler instead.'.format(content_type))
+        self.handlers[content_type] = handler
+
+    def overwrite_handler(self, content_type, handler):
+        if content_type not in self.handlers:
+            raise SyncanoException('Handler "{}" not defined. User register_handler instead.'.format(content_type))
         self.handlers[content_type] = handler
 
     def process_response(self, response):
@@ -38,19 +88,26 @@ class CustomResponseHandler(object):
     def plain_handler(response):
         return response['response']['content']
 
-custom_response_handler = CustomResponseHandler()
-custom_response_handler.register_handler('application/json', CustomResponseHandler.json_handler)
-custom_response_handler.register_handler('text/plain', CustomResponseHandler.plain_handler)
-
 
 class CustomResponseMixin(object):
+    """
+    A mixin which extends the CodeBox and Webhook traces (and any other Model - if used) with following fields:
+      * content - This is the response data if set_response is used in CodeBox code, otherwise it is the 'stdout' field;
+      * content_type - The content_type specified by the user in CodeBox code;
+      * status_code - The status_code specified by the user in CodeBox code;
+      * error - An error which can occur when code is executed: the stderr response field;
+
+    To process the content based on content_type this Mixin uses the CustomResponseHandler - see the docs there.
+    """
+
+    response_handler = CustomResponseHandler()
 
     @property
     def content(self):
-        return custom_response_handler.process_response(self.result)
+        return self.response_handler.process_response(self.result)
 
     @property
-    def response_status(self):
+    def status_code(self):
         return self.result.get('response', {}).get('status')
 
     @property

--- a/syncano/models/incentives.py
+++ b/syncano/models/incentives.py
@@ -275,10 +275,12 @@ class Webhook(Model):
         connection = self._get_connection(**payload)
 
         response = connection.request('POST', endpoint, **{'data': payload})
-
-        response.update({'instance_name': self.instance_name,
-                         'webhook_name': self.name})
-        return WebhookTrace(**response)
+        if 'result' in response and 'stdout' in response['result']:
+            response.update({'instance_name': self.instance_name,
+                             'webhook_name': self.name})
+            return WebhookTrace(**response)
+        # if codebox is a custom one, return result 'as-it-is';
+        return response
 
     def reset_link(self):
         """

--- a/syncano/models/traces.py
+++ b/syncano/models/traces.py
@@ -1,11 +1,12 @@
 from __future__ import unicode_literals
 
+from .custom_response import CustomResponseMixin
 from . import fields
 from .base import Model
 from .incentives import CodeBox, Schedule, Trigger, Webhook
 
 
-class CodeBoxTrace(Model):
+class CodeBoxTrace(CustomResponseMixin, Model):
     """
     :ivar status: :class:`~syncano.models.fields.ChoiceField`
     :ivar links: :class:`~syncano.models.fields.HyperlinkedField`
@@ -26,7 +27,7 @@ class CodeBoxTrace(Model):
     status = fields.ChoiceField(choices=STATUS_CHOICES, read_only=True, required=False)
     links = fields.HyperlinkedField(links=LINKS)
     executed_at = fields.DateTimeField(read_only=True, required=False)
-    result = fields.StringField(read_only=True, required=False)
+    result = fields.JSONField(read_only=True, required=False)
     duration = fields.IntegerField(read_only=True, required=False)
 
     class Meta:
@@ -119,7 +120,7 @@ class TriggerTrace(Model):
         }
 
 
-class WebhookTrace(Model):
+class WebhookTrace(CustomResponseMixin, Model):
     """
     :ivar status: :class:`~syncano.models.fields.ChoiceField`
     :ivar links: :class:`~syncano.models.fields.HyperlinkedField`
@@ -140,7 +141,7 @@ class WebhookTrace(Model):
     status = fields.ChoiceField(choices=STATUS_CHOICES, read_only=True, required=False)
     links = fields.HyperlinkedField(links=LINKS)
     executed_at = fields.DateTimeField(read_only=True, required=False)
-    result = fields.StringField(read_only=True, required=False)
+    result = fields.JSONField(read_only=True, required=False)
     duration = fields.IntegerField(read_only=True, required=False)
 
     class Meta:

--- a/syncano/models/traces.py
+++ b/syncano/models/traces.py
@@ -1,8 +1,8 @@
 from __future__ import unicode_literals
 
-from .custom_response import CustomResponseMixin
 from . import fields
 from .base import Model
+from .custom_response import CustomResponseMixin
 from .incentives import CodeBox, Schedule, Trigger, Webhook
 
 

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -356,7 +356,7 @@ set_response(HttpResponse(status_code=200, content='{"one": 1}', content_type='a
             trace.reload()
 
         self.assertEquals(trace.status, 'success')
-        self.assertDictEqual(trace.content, {'one', 1})
+        self.assertDictEqual(trace.content, {'one': 1})
         self.assertEqual(trace.contet_type, 'application/json')
         self.assertEqual(trace.status_code, 200)
 
@@ -428,6 +428,5 @@ set_response(HttpResponse(status_code=200, content='{"one": 1}', content_type='a
         )
 
         trace = webhook.run()
-        self.assertEquals(trace.status, 'success')
-        self.assertDictEqual(trace.content, {'one': 1})
+        self.assertDictEqual(trace, {'one': 1})
         webhook.delete()

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -337,7 +337,7 @@ class CodeboxIntegrationTest(InstanceMixin, IntegrationTest):
             trace.reload()
 
         self.assertEquals(trace.status, 'success')
-        self.assertEquals(trace.result, u'{u\'stderr\': u\'\', u\'stdout\': u\'IntegrationTest\'}')
+        self.assertDictEqual(trace.result, {u'stderr': u'', u'stdout': u'IntegrationTest'})
 
         codebox.delete()
 
@@ -388,5 +388,5 @@ class WebhookIntegrationTest(InstanceMixin, IntegrationTest):
 
         trace = webhook.run()
         self.assertEquals(trace.status, 'success')
-        self.assertEquals(trace.result, u'{u\'stderr\': u\'\', u\'stdout\': u\'IntegrationTest\'}')
+        self.assertDictEqual(trace.result, {u'stderr': u'', u'stdout': u'IntegrationTest'})
         webhook.delete()

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -357,7 +357,7 @@ set_response(HttpResponse(status_code=200, content='{"one": 1}', content_type='a
 
         self.assertEquals(trace.status, 'success')
         self.assertDictEqual(trace.content, {'one': 1})
-        self.assertEqual(trace.contet_type, 'application/json')
+        self.assertEqual(trace.content_type, 'application/json')
         self.assertEqual(trace.status_code, 200)
 
         codebox.delete()

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -341,6 +341,27 @@ class CodeboxIntegrationTest(InstanceMixin, IntegrationTest):
 
         codebox.delete()
 
+    def test_custom_response_run(self):
+        codebox = self.model.please.create(
+            instance_name=self.instance.name,
+            label='cb%s' % self.generate_hash()[:10],
+            runtime_name='python',
+            source="""
+set_response(HttpResponse(status_code=200, content='{"one": 1}', content_type='application/json'))"""
+        )
+
+        trace = codebox.run()
+        while trace.status == 'pending':
+            sleep(1)
+            trace.reload()
+
+        self.assertEquals(trace.status, 'success')
+        self.assertDictEqual(trace.content, {'one', 1})
+        self.assertEqual(trace.contet_type, 'application/json')
+        self.assertEqual(trace.status_code, 200)
+
+        codebox.delete()
+
 
 class WebhookIntegrationTest(InstanceMixin, IntegrationTest):
     model = Webhook
@@ -354,6 +375,14 @@ class WebhookIntegrationTest(InstanceMixin, IntegrationTest):
             label='cb%s' % cls.generate_hash()[:10],
             runtime_name='python',
             source='print "IntegrationTest"'
+        )
+
+        cls.custom_codebox = CodeBox.please.create(
+            instance_name=cls.instance.name,
+            label='cb%s' % cls.generate_hash()[:10],
+            runtime_name='python',
+            source="""
+set_response(HttpResponse(status_code=200, content='{"one": 1}', content_type='application/json'))"""
         )
 
     @classmethod
@@ -389,4 +418,16 @@ class WebhookIntegrationTest(InstanceMixin, IntegrationTest):
         trace = webhook.run()
         self.assertEquals(trace.status, 'success')
         self.assertDictEqual(trace.result, {u'stderr': u'', u'stdout': u'IntegrationTest'})
+        webhook.delete()
+
+    def test_custom_codebox_run(self):
+        webhook = self.model.please.create(
+            instance_name=self.instance.name,
+            codebox=self.custom_codebox.id,
+            name='wh%s' % self.generate_hash()[:10],
+        )
+
+        trace = webhook.run()
+        self.assertEquals(trace.status, 'success')
+        self.assertDictEqual(trace.content, {'one': 1})
         webhook.delete()

--- a/tests/test_custom_response.py
+++ b/tests/test_custom_response.py
@@ -1,7 +1,7 @@
 import json
 import unittest
 
-from syncano.models import CustomResponseHandler
+from syncano.models.custom_response import CustomResponseHandler
 
 
 class ObjectTestCase(unittest.TestCase):

--- a/tests/test_custom_response.py
+++ b/tests/test_custom_response.py
@@ -1,0 +1,33 @@
+import json
+import unittest
+
+from syncano.models import CustomResponseHandler
+
+
+class ObjectTestCase(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.json_data = json.dumps({'one': 1, 'two': 2})
+
+    def _wrap_data(self):
+        return {'response': {'content': self.json_data, 'content_type': 'application/json'}}
+
+    def test_default_json_handler(self):
+        custom_handler = CustomResponseHandler()
+        processed_data = custom_handler.process_response(self._wrap_data())
+
+        self.assertDictEqual(processed_data, json.loads(self.json_data))
+
+    def test_custom_json_handler(self):
+
+        def json_custom_handler(response):
+            #  return only two
+            return json.loads(response['response']['content'])['two']
+
+        custom_handler = CustomResponseHandler()
+        custom_handler.overwrite_handler('application/json', json_custom_handler)
+
+        processed_data = custom_handler.process_response(self._wrap_data())
+
+        self.assertEqual(processed_data, json.loads(self.json_data)['two'])

--- a/tests/test_incentives.py
+++ b/tests/test_incentives.py
@@ -61,7 +61,7 @@ class WebhookTestCase(unittest.TestCase):
         self.assertIsInstance(result, WebhookTrace)
         self.assertEqual(result.status, 'success')
         self.assertEqual(result.duration, 937)
-        self.assertEqual(result.result, '1')
+        self.assertEqual(result.result, 1)
         self.assertIsInstance(result.executed_at, datetime)
 
         connection_mock.assert_called_once_with(x=1, y=2)

--- a/tests/test_incentives.py
+++ b/tests/test_incentives.py
@@ -49,7 +49,7 @@ class WebhookTestCase(unittest.TestCase):
         connection_mock.request.return_value = {
             'status': 'success',
             'duration': 937,
-            'result': 1,
+            'result': {u'stdout': 1, u'stderr': u''},
             'executed_at': '2015-03-16T11:52:14.172830Z'
         }
 
@@ -61,7 +61,7 @@ class WebhookTestCase(unittest.TestCase):
         self.assertIsInstance(result, WebhookTrace)
         self.assertEqual(result.status, 'success')
         self.assertEqual(result.duration, 937)
-        self.assertEqual(result.result, 1)
+        self.assertEqual(result.result, {u'stdout': 1, u'stderr': u''})
         self.assertIsInstance(result.executed_at, datetime)
 
         connection_mock.assert_called_once_with(x=1, y=2)

--- a/tests/test_incentives.py
+++ b/tests/test_incentives.py
@@ -49,7 +49,7 @@ class WebhookTestCase(unittest.TestCase):
         connection_mock.request.return_value = {
             'status': 'success',
             'duration': 937,
-            'result': '1',
+            'result': 1,
             'executed_at': '2015-03-16T11:52:14.172830Z'
         }
 

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -490,7 +490,7 @@ class WebhookManagerTestCase(unittest.TestCase):
         request_mock.return_value = {
             'status': 'success',
             'duration': 937,
-            'result': '1',
+            'result': 1,
             'executed_at': '2015-03-16T11:52:14.172830Z'
         }
 
@@ -501,7 +501,7 @@ class WebhookManagerTestCase(unittest.TestCase):
         self.assertIsInstance(result, WebhookTrace)
         self.assertEqual(result.status, 'success')
         self.assertEqual(result.duration, 937)
-        self.assertEqual(result.result, '1')
+        self.assertEqual(result.result, 1)
         self.assertIsInstance(result.executed_at, datetime)
 
         self.assertTrue(filter_mock.called)


### PR DESCRIPTION
Guys @dancio @Zhebr @23doors , before make some test and usage, could you please take a look and tell me if you like/dislike this approach? Would be very thankful :)

I have one more question here:
What content types we should support ad-hoc? 
I want to give lib user ability to define their own handlers, but think we should have some ready to use immediately. Currently only: application/json and text/plain are supported.