### PR TITLE
[certifi] Certifi version fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     ],
     install_requires=[
         'requests==2.7.0',
-        'certifi',
+        'certifi==2015.09.06.2',
         'ndg-httpsclient==0.4.0',
         'pyasn1==0.1.8',
         'pyOpenSSL==0.15.1',


### PR DESCRIPTION
Newest version removed 1024bit CA certificates and 2048 bit ones have some issues with openssl < 1.0.2 (which is pretty new and only a part of newest ubuntu and debian sid).