### PR TITLE
[DISCUSSION ONLY][LIB-342] Initial try for cleaning up the update method;

### DIFF
--- a/syncano/models/manager.py
+++ b/syncano/models/manager.py
@@ -221,17 +221,20 @@ class Manager(ConnectionMixin):
         self.is_lazy = False
 
         meta = []
+        requests = []
         for arg in args:
             if isinstance(arg, list):  # update now can return a list;
                 for nested_arg in arg:
                     meta.append(nested_arg['meta'])
+                    requests.append(nested_arg['body'])
             else:
                 meta.append(arg['meta'])
+                requests.append(arg['body'])
 
         response = self.connection.request(
             'POST',
             self.BATCH_URI.format(name=registry.last_used_instance),
-            **{'data': {'requests': [arg['body'] for arg in args]}}
+            **{'data': {'requests': requests}}
         )
 
         populated_response = []

--- a/syncano/models/manager.py
+++ b/syncano/models/manager.py
@@ -453,6 +453,33 @@ class Manager(ConnectionMixin):
 
         return self.model.batch_object(method=self.method, path=path, body=self.data, properties=defaults)
 
+    @clone
+    def filter_by_attributes(self, *args, **kwargs):
+        self._filter(*args, **kwargs)
+        return self
+
+    @clone
+    def do_update(self, *args, **kwargs):
+        self.endpoint = 'detail'
+        self.method = self.get_allowed_method('PATCH', 'PUT', 'POST')
+        self.data = kwargs
+
+        model = self.serialize(self.data, self.model)
+
+        serialized = model.to_native()
+
+        serialized = {k: v for k, v in serialized.iteritems()
+                      if k in self.data}
+
+        self.data.update(serialized)
+
+        if not self.is_lazy:
+            return self.request()
+
+        path, defaults = self._get_endpoint_properties()
+
+        return self.model.batch_object(method=self.method, path=path, body=self.data, properties=defaults)
+
     def update_or_create(self, defaults=None, **kwargs):
         """
         A convenience method for updating an object with the given parameters, creating a new one if necessary.

--- a/tests/integration_test_batch.py
+++ b/tests/integration_test_batch.py
@@ -88,7 +88,7 @@ class ManagerBatchTest(InstanceMixin, IntegrationTest):
     def test_batch_mix(self):
         mix_batches = Object.please.batch(
             self.klass.objects.as_batch().create(title='four'),
-            self.klass.objects.as_batch().update(title='TerminatorArrival', id=self.update3.id),
+            self.klass.objects.as_batch().filter(id=self.update3.id).update(title='TerminatorArrival'),
             self.klass.objects.as_batch().delete(id=self.delete3.id)
         )
 

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -586,23 +586,17 @@ class ObjectManagerTestCase(unittest.TestCase):
 
     @mock.patch('syncano.models.manager.Manager.request')
     @mock.patch('syncano.models.manager.ObjectManager.serialize')
-    def test_update(self, serialize_mock, request_mock):
+    @mock.patch('syncano.models.manager.Manager.iterator')
+    def test_update(self, iterator_mock, serialize_mock, request_mock):
+        iterator_mock.return_value = [Object(class_name='test', instance_name='test')]
         serialize_mock.return_value = serialize_mock
         self.assertFalse(serialize_mock.called)
 
-        self.model.please.update(
-            id=20,
-            class_name='test',
-            instance_name='test',
-            fieldb='23',
-            data={
-                'fielda': 1,
-                'fieldb': None
-            })
+        self.model.please.list(class_name='test', instance_name='test').filter(id=20).update(fielda=1, fieldb=None)
 
         self.assertTrue(serialize_mock.called)
         serialize_mock.assert_called_once_with(
-            {'class_name': 'test', 'instance_name': 'test', 'fielda': 1, 'id': 20, 'fieldb': None},
+            {'fielda': 1, 'fieldb': None},
             self.model
         )
 


### PR DESCRIPTION
@dancio @Zhebr Well I need a discussion here :) 

Technically it rather an easy task (chill and do not look at code repetition and not DRY - correct this when ready) - look at the changes. On this branch is possible to make update like this:

```
o = Object.please.filter_by_attributes(
    class_name='someclass',
    id=1
).do_update(
    aarg='Some data 51'  # currently totally removed the idea of updating through 'data' kwarg 
)
```

This separates the 'filter' args & kwargs with 'update to' args & kwargs;
The 'filter_by_attributes' runs _filter under the hood, and sets manager properties;
do_update - making a update request with provided data;

But! Yep, always 'but' ;)

I have a big problem to name this methods properly - 'filter' is already taken (specific for DataObject), 'query' - is also taken (it's some kind of dict storing query params on manager); And of course - 'update' is also taken :), I think we should leave the 'old style' update - and do not break the compatibility - but maybe we should totally rebuild the update? What do you think guys?; 

If all this is taken into consideration - the change looks like forced one (if two possibilities will stay). 

Beside that - this filter (currently named as filter_by_attributes) is doing different job than DataObject.filter() -> Any ideas how to distinguish this? And do not make confusion?

Pls Halp!

